### PR TITLE
added Open In Sourcegraph button for VCS / Git revisions

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,9 @@ Please file an issue: https://github.com/sourcegraph/sourcegraph-jetbrains/issue
 
 ## Version History
 
+#### v1.2.1
+- Added `Open In Sourcegraph` action to VCS History and Git Log to open a revision in the Sourcegraph diff view.
+
 #### v1.2.0
 
 - The search menu entry is now no longer present when no text has been selected.

--- a/build.gradle
+++ b/build.gradle
@@ -17,6 +17,15 @@ intellij {
     sandboxDirectory 'idea-sandbox'
 }
 
+dependencies {
+    testImplementation(platform('org.junit:junit-bom:5.7.2'))
+    testImplementation('org.junit.jupiter:junit-jupiter')
+}
+
+test {
+    useJUnitPlatform()
+}
+
 runIde {
     systemProperty("idea.is.internal", true)
 }

--- a/src/main/java/CommitViewUriBuilder.java
+++ b/src/main/java/CommitViewUriBuilder.java
@@ -1,0 +1,37 @@
+import com.google.common.base.Strings;
+import java.io.UnsupportedEncodingException;
+import java.net.URI;
+import java.net.URLEncoder;
+
+public class CommitViewUriBuilder {
+
+  public URI build(String sourcegraphBase, String revisionNumber, RepoInfo repoInfo, String productName, String productVersion) {
+    if (Strings.isNullOrEmpty(sourcegraphBase)) {
+      throw new RuntimeException("Missing sourcegraph URI for commit uri.");
+    } else if (Strings.isNullOrEmpty(revisionNumber)) {
+      throw new RuntimeException("Missing revision number for commit uri.");
+    } else if (repoInfo == null || Strings.isNullOrEmpty(repoInfo.remoteURL)) {
+      throw new RuntimeException("Missing remote URL for commit uri.");
+    }
+
+    // this is pretty hacky but to try to build the repo string we will just try to naively parse the git remote uri. Worst case scenario this 404s
+    URI remote = URI.create(repoInfo.remoteURL);
+    String path = remote.getPath().replace(".git", "");
+
+    StringBuilder builder = new StringBuilder();
+    try {
+      builder.append(sourcegraphBase);
+      builder.append(String.format("/%s%s", remote.getHost(), path));
+      builder.append(String.format("/-/commit/%s", revisionNumber));
+      builder.append(String.format("?editor=%s", URLEncoder.encode("JetBrains", "UTF-8")));
+      builder.append(String.format("&version=%s", URLEncoder.encode(Util.VERSION, "UTF-8")));
+      builder.append(String.format("&utm_product_name=%s", URLEncoder.encode(productName, "UTF-8")));
+      builder.append(String.format("&utm_product_version=%s", URLEncoder.encode(productVersion, "UTF-8")));
+    } catch (UnsupportedEncodingException e) {
+      e.printStackTrace();
+    }
+
+    return URI.create(builder.toString());
+  }
+
+}

--- a/src/main/java/OpenRevisionAction.java
+++ b/src/main/java/OpenRevisionAction.java
@@ -1,0 +1,81 @@
+import com.intellij.openapi.actionSystem.AnAction;
+import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.intellij.openapi.application.ApplicationInfo;
+import com.intellij.openapi.project.DumbAware;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.vcs.VcsDataKeys;
+import com.intellij.openapi.vcs.history.VcsFileRevision;
+import com.intellij.vcs.log.VcsLog;
+import com.intellij.vcs.log.VcsLogDataKeys;
+import java.awt.Desktop;
+import java.io.IOException;
+import java.net.URI;
+import java.util.Optional;
+import org.apache.log4j.LogManager;
+import org.apache.log4j.Logger;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Jetbrains IDE action to open a selected revision in Sourcegraph.
+ */
+public class OpenRevisionAction extends AnAction implements DumbAware {
+  private final Logger logger = LogManager.getLogger(this.getClass());
+
+  private Optional<RevisionContext> getHistoryRevision(AnActionEvent e) {
+    VcsFileRevision revision = e.getDataContext().getData(VcsDataKeys.VCS_FILE_REVISION);
+    Project project = e.getProject();
+
+    if (project == null) {
+      return Optional.empty();
+    }
+    if (revision == null) {
+      return Optional.empty();
+    }
+
+    String rev = revision.getRevisionNumber().toString();
+    return Optional.of(new RevisionContext(project, rev));
+  }
+
+  private Optional<RevisionContext> getLogRevision(AnActionEvent e) {
+    VcsLog log = e.getDataContext().getData(VcsLogDataKeys.VCS_LOG);
+    Project project = e.getProject();
+
+    if (project == null) {
+      return Optional.empty();
+    }
+    if (log == null || log.getSelectedCommits().isEmpty()) {
+      return Optional.empty();
+    }
+
+    String rev = log.getSelectedCommits().get(0).getHash().asString();
+    return Optional.of(new RevisionContext(project, rev));
+  }
+
+  @Override
+  public void actionPerformed(@NotNull AnActionEvent e) {
+    // This action handles events for both log and history views, so attempt to load from any possible option.
+    RevisionContext context = getHistoryRevision(e).map(Optional::of)
+        .orElseGet(() -> getLogRevision(e))
+        .orElseThrow(() -> new RuntimeException("Unable to determine revision from history or log."));
+
+    try {
+      String productName = ApplicationInfo.getInstance().getVersionName();
+      String productVersion = ApplicationInfo.getInstance().getFullVersion();
+      RepoInfo repoInfo = Util.repoInfo(context.getProject().getProjectFilePath());
+
+      CommitViewUriBuilder builder = new CommitViewUriBuilder();
+      URI uri = builder.build(Util.sourcegraphURL(context.getProject()), context.getRevisionNumber(), repoInfo, productName, productVersion);
+
+      // Open the URL in the browser.
+      Desktop.getDesktop().browse(uri);
+    } catch (IOException err) {
+      logger.debug("failed to open browser");
+      err.printStackTrace();
+    }
+  }
+
+  @Override
+  public void update(@NotNull AnActionEvent e) {
+    e.getPresentation().setEnabledAndVisible(true);
+  }
+}

--- a/src/main/java/RevisionContext.java
+++ b/src/main/java/RevisionContext.java
@@ -1,0 +1,19 @@
+import com.intellij.openapi.project.Project;
+
+public class RevisionContext {
+  private final Project project;
+  private final String revisionNumber;
+
+  public RevisionContext(Project project, String revisionNumber) {
+    this.project = project;
+    this.revisionNumber = revisionNumber;
+  }
+
+  public Project getProject() {
+    return project;
+  }
+
+  public String getRevisionNumber() {
+    return revisionNumber;
+  }
+}

--- a/src/main/java/Util.java
+++ b/src/main/java/Util.java
@@ -5,7 +5,7 @@ import java.io.*;
 import java.util.Properties;
 
 public class Util {
-    public static String VERSION = "v1.2.0";
+    public static String VERSION = "v1.2.1";
 
     // gitRemoteURL returns the remote URL for the given remote name.
     // e.g. "origin" -> "git@github.com:foo/bar"

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -15,6 +15,11 @@
 
   <change-notes><![CDATA[
     <ul>
+      <li>v1.2.1 - Open Revision in Sourcegraph
+       <ul>
+          <li>Added "Open In Sourcegraph" action to VCS History and Git Log to open a revision in the Sourcegraph diff view.</li>
+        </ul>
+      </li>
       <li>v1.2.0 - Copy link to file, search in repository, per-repository configuration, bug fixes & more
        <ul>
           <li>The search menu entry is now no longer present when no text has been selected.</li>
@@ -82,6 +87,12 @@
       <reference ref="sourcegraph.copy"/>
       <add-to-group anchor="last" group-id="EditorPopupMenu"/>
     </group>
+    <action id="OpenRevisionAction" icon="/icons/icon.png" class="OpenRevisionAction" text="Open In Sourcegraph" description="Open revision diff in Sourcegraph">
+      <add-to-group group-id="VcsHistoryActionsGroup" anchor="last"/>
+      <add-to-group group-id="Vcs.Log.ContextMenu" anchor="last"/>
+      <add-to-group group-id="VcsHistoryActionsGroup.Toolbar" anchor="last"/>
+      <add-to-group group-id="VcsSelectionHistoryDialog.Popup" anchor="last"/>
+    </action>
   </actions>
 
 </idea-plugin>

--- a/src/test/java/CommitViewUriBuilderTest.java
+++ b/src/test/java/CommitViewUriBuilderTest.java
@@ -1,0 +1,72 @@
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.net.URI;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EmptySource;
+import org.junit.jupiter.params.provider.NullSource;
+
+public class CommitViewUriBuilderTest {
+
+  @Test
+  public void testBuild_AllValid() {
+    CommitViewUriBuilder builder = new CommitViewUriBuilder();
+
+    RepoInfo repoInfo = new RepoInfo("", "https://github.com/sourcegraph/sourcegraph-jetbrains.git", "main");
+
+    URI got = builder.build("https://www.sourcegraph.com",
+        "1fa8d5d6286c24924b55c15ed4d1a0b85ccab4d5",
+        repoInfo,
+        "intellij",
+        "1.1");
+
+    String want = "https://www.sourcegraph.com/github.com/sourcegraph/sourcegraph-jetbrains/-/commit/1fa8d5d6286c24924b55c15ed4d1a0b85ccab4d5?editor=JetBrains&version=v1.2.0&utm_product_name=intellij&utm_product_version=1.1";
+    assertEquals(want, got.toString());
+  }
+
+  @ParameterizedTest
+  @NullSource
+  @EmptySource
+  public void testBuild_MissingRevision(String revision) {
+    CommitViewUriBuilder builder = new CommitViewUriBuilder();
+    RepoInfo repoInfo = new RepoInfo("", "https://github.com/sourcegraph/sourcegraph-jetbrains.git", "main");
+
+    assertThrows(RuntimeException.class, () -> builder.build("https://www.sourcegraph.com",
+        revision,
+        repoInfo,
+        "intellij",
+        "1.1"));
+  }
+
+  @ParameterizedTest
+  @NullSource
+  @EmptySource
+  public void testBuild_MissingBaseUri(String baseUri) {
+    CommitViewUriBuilder builder = new CommitViewUriBuilder();
+    RepoInfo repoInfo = new RepoInfo("", "https://github.com/sourcegraph/sourcegraph-jetbrains.git", "main");
+
+    assertThrows(RuntimeException.class, () -> builder.build(baseUri,
+        "1fa8d5d6286c24924b55c15ed4d1a0b85ccab4d5",
+        repoInfo,
+        "intellij",
+        "1.1"));
+  }
+  @Test
+  public void testBuild_MissingRemoteUrl() {
+    CommitViewUriBuilder builder = new CommitViewUriBuilder();
+    RepoInfo repoInfo = new RepoInfo("", "", "main");
+
+    assertThrows(RuntimeException.class, () -> builder.build("https://www.sourcegraph.com",
+        "1fa8d5d6286c24924b55c15ed4d1a0b85ccab4d5",
+        repoInfo,
+        "intellij",
+        "1.1"));
+
+    assertThrows(RuntimeException.class, () -> builder.build("https://www.sourcegraph.com",
+        "1fa8d5d6286c24924b55c15ed4d1a0b85ccab4d5",
+        null,
+        "intellij",
+        "1.1"));
+  }
+}


### PR DESCRIPTION
I was working the other day and realized we can't open a revision into the diff view of Sourcegraph. This adds this functionality to the history and log panels of Jetbrains editors.

Images below, the button opens a link such as [this](https://sourcegraph.com/github.com/sourcegraph/sourcegraph-jetbrains/-/commit/bebc5b38fe42105a3b427d4b44202b46571efac9?editor=JetBrains&version=v1.2.1&utm_product_name=IntelliJ+IDEA&utm_product_version=2020.1)

![history_menu](https://user-images.githubusercontent.com/5090588/126910518-6b70e228-fe4b-4ff1-853e-7b94c4d0ab2c.PNG)
![history_selection_context](https://user-images.githubusercontent.com/5090588/126910519-c2598152-d9d4-4ff7-ae7b-950e8a520770.PNG)
![log_context_menu](https://user-images.githubusercontent.com/5090588/126910520-ff563e28-30ef-4ce5-a566-98727cb0b16f.PNG)
