### PR TITLE
feat: Add option to replace values in remote url

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,9 @@ The plugin is configurable _globally_ by creating a `sourcegraph-jetbrains.prope
 
 ```
 url = https://sourcegraph.example.com
+defaultBranch = example-branch
+# At least two values are required for remoteUrlReplacements to work, with four as the maximum.
+remoteUrlReplacements = git.example.com, git-web.example.com
 ```
 
 You may also choose to configure it _per repository_ using a `.idea/sourcegraph.xml` file in your repository like so:
@@ -43,6 +46,8 @@ You may also choose to configure it _per repository_ using a `.idea/sourcegraph.
 <project version="4">
     <component name="Config">
         <option name="url" value="https://sourcegraph.example.com" />
+        <option name="defaultBranch" value="example-branch" />
+        <option name="remoteUrlReplacements" value="git.example.com, git-web.example.com" />
     </component>
 </project>
 ```
@@ -78,6 +83,8 @@ Please file an issue: https://github.com/sourcegraph/sourcegraph-jetbrains/issue
 
 #### v1.2.1
 - Added `Open In Sourcegraph` action to VCS History and Git Log to open a revision in the Sourcegraph diff view.
+- Added `defaultBranch` configuration option that allows opening files in a specific branch on Sourcegraph.
+- Added `remoteUrlReplacements` configuration option that allow users to replace specified values in the remote url with new strings.
 
 #### v1.2.0
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,6 @@ The plugin is configurable _globally_ by creating a `sourcegraph-jetbrains.prope
 ```
 url = https://sourcegraph.example.com
 defaultBranch = example-branch
-# At least two values are required for remoteUrlReplacements to work, with four as the maximum.
 remoteUrlReplacements = git.example.com, git-web.example.com
 ```
 

--- a/src/main/java/Config.java
+++ b/src/main/java/Config.java
@@ -23,6 +23,12 @@ class Config implements PersistentStateComponent<Config> {
         return defaultBranch;
     }
 
+    public String remoteUrlReplacements;
+
+    public String getRemoteUrlReplacements() {
+        return remoteUrlReplacements;
+    }
+
     @Nullable
     @Override
     public Config getState() {
@@ -33,6 +39,7 @@ class Config implements PersistentStateComponent<Config> {
     public void loadState(@NotNull Config config) {
         this.url = config.url;
         this.defaultBranch = config.defaultBranch;
+        this.remoteUrlReplacements = config.remoteUrlReplacements;
     }
 
     @Nullable static Config getInstance(Project project) {

--- a/src/main/java/FileAction.java
+++ b/src/main/java/FileAction.java
@@ -64,9 +64,13 @@ public abstract class FileAction extends AnAction {
         if(Util.setRemoteUrlReplacements(project)!=null) {
             String r = Util.setRemoteUrlReplacements(project);
             String[] replacements = r.trim().split("\\s*,\\s*");
-            // Check if the entered values are pair
-            if(replacements.length==2) {
-                remoteURL = remoteURL.replace(replacements[0], replacements[1]);
+            // Check if the entered values are pairs with no more than 2 pairs
+            Integer i = 0;
+            if(replacements.length%2==0 && replacements.length<=4) {
+                while(i< replacements.length) {
+                    remoteURL = remoteURL.replace(replacements[i], replacements[i+1]);
+                    i+=2;
+                }
             }
         }
 

--- a/src/main/java/FileAction.java
+++ b/src/main/java/FileAction.java
@@ -16,6 +16,8 @@ import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.net.URI;
 import java.net.URLEncoder;
+import java.util.Arrays;
+import java.util.List;
 
 public abstract class FileAction extends AnAction {
 
@@ -54,18 +56,25 @@ public abstract class FileAction extends AnAction {
         String productName = ApplicationInfo.getInstance().getVersionName();
         String productVersion = ApplicationInfo.getInstance().getFullVersion();
         String uri;
-        String branch = repoInfo.branch;
+        // set defaultBranch if config option is not null
+        String branch = Util.setDefaultBranch(project)!=null ? Util.setDefaultBranch(project) : repoInfo.branch;
+        String remoteURL = repoInfo.remoteURL;
 
-        // set defaultBranch only if not config is not null
-        if(Util.setDefaultBranch(project)!=null) {
-            branch = Util.setDefaultBranch(project);
-        };
+        // replace remoteURL if config option is not null
+        if(Util.setRemoteUrlReplacements(project)!=null) {
+            String r = Util.setRemoteUrlReplacements(project);
+            String[] replacements = r.trim().split("\\s*,\\s*");
+            // Check if the entered values are pair
+            if(replacements.length==2) {
+                remoteURL = remoteURL.replace(replacements[0], replacements[1]);
+            }
+        }
 
         try {
             LogicalPosition start = editor.visualToLogicalPosition(sel.getSelectionStartPosition());
             LogicalPosition end = editor.visualToLogicalPosition(sel.getSelectionEndPosition());
             uri = Util.sourcegraphURL(project)+"-/editor"
-                    + "?remote_url=" + URLEncoder.encode(repoInfo.remoteURL, "UTF-8")
+                    + "?remote_url=" + URLEncoder.encode(remoteURL, "UTF-8")
                     + "&branch=" + URLEncoder.encode(branch, "UTF-8")
                     + "&file=" + URLEncoder.encode(repoInfo.fileRel, "UTF-8")
                     + "&editor=" + URLEncoder.encode("JetBrains", "UTF-8")

--- a/src/main/java/FileAction.java
+++ b/src/main/java/FileAction.java
@@ -47,7 +47,7 @@ public abstract class FileAction extends AnAction {
         SelectionModel sel = editor.getSelectionModel();
 
         // Get repo information.
-        RepoInfo repoInfo = Util.repoInfo(currentFile.getPath());
+        RepoInfo repoInfo = Util.repoInfo(currentFile.getPath(), project);
         if (repoInfo.remoteURL == "") {
             return;
         }
@@ -56,26 +56,13 @@ public abstract class FileAction extends AnAction {
         String productName = ApplicationInfo.getInstance().getVersionName();
         String productVersion = ApplicationInfo.getInstance().getFullVersion();
         String uri;
-        // set defaultBranch if config option is not null
-        String branch = Util.setDefaultBranch(project)!=null ? Util.setDefaultBranch(project) : repoInfo.branch;
-        String remoteURL = repoInfo.remoteURL;
-
-        // replace remoteURL if config option is not null
-        if(Util.setRemoteUrlReplacements(project)!=null) {
-            String r = Util.setRemoteUrlReplacements(project);
-            String[] replacements = r.trim().split("\\s*,\\s*");
-            // Check if the entered values are pairs with no more than 2 pairs
-             for (int i = 0; i < replacements.length && replacements.length % 2 == 0; i += 2) {
-                remoteURL = remoteURL.replace(replacements[i], replacements[i+1]);
-            }
-        }
 
         try {
             LogicalPosition start = editor.visualToLogicalPosition(sel.getSelectionStartPosition());
             LogicalPosition end = editor.visualToLogicalPosition(sel.getSelectionEndPosition());
             uri = Util.sourcegraphURL(project)+"-/editor"
-                    + "?remote_url=" + URLEncoder.encode(remoteURL, "UTF-8")
-                    + "&branch=" + URLEncoder.encode(branch, "UTF-8")
+                    + "?remote_url=" + URLEncoder.encode(repoInfo.remoteURL, "UTF-8")
+                    + "&branch=" + URLEncoder.encode(repoInfo.branch, "UTF-8")
                     + "&file=" + URLEncoder.encode(repoInfo.fileRel, "UTF-8")
                     + "&editor=" + URLEncoder.encode("JetBrains", "UTF-8")
                     + "&version=" + URLEncoder.encode(Util.VERSION, "UTF-8")

--- a/src/main/java/FileAction.java
+++ b/src/main/java/FileAction.java
@@ -65,12 +65,8 @@ public abstract class FileAction extends AnAction {
             String r = Util.setRemoteUrlReplacements(project);
             String[] replacements = r.trim().split("\\s*,\\s*");
             // Check if the entered values are pairs with no more than 2 pairs
-            Integer i = 0;
-            if(replacements.length%2==0 && replacements.length<=4) {
-                while(i< replacements.length) {
-                    remoteURL = remoteURL.replace(replacements[i], replacements[i+1]);
-                    i+=2;
-                }
+             for (int i = 0; i < replacements.length && replacements.length % 2 == 0; i += 2) {
+                remoteURL = remoteURL.replace(replacements[i], replacements[i+1]);
             }
         }
 

--- a/src/main/java/OpenRevisionAction.java
+++ b/src/main/java/OpenRevisionAction.java
@@ -61,7 +61,7 @@ public class OpenRevisionAction extends AnAction implements DumbAware {
     try {
       String productName = ApplicationInfo.getInstance().getVersionName();
       String productVersion = ApplicationInfo.getInstance().getFullVersion();
-      RepoInfo repoInfo = Util.repoInfo(context.getProject().getProjectFilePath());
+      RepoInfo repoInfo = Util.repoInfo(context.getProject().getProjectFilePath(), context.getProject());
 
       CommitViewUriBuilder builder = new CommitViewUriBuilder();
       URI uri = builder.build(Util.sourcegraphURL(context.getProject()), context.getRevisionNumber(), repoInfo, productName, productVersion);

--- a/src/main/java/SearchActionBase.java
+++ b/src/main/java/SearchActionBase.java
@@ -40,7 +40,7 @@ public abstract class SearchActionBase extends AnAction {
         SelectionModel sel = editor.getSelectionModel();
 
         // Get repo information.
-        RepoInfo repoInfo = Util.repoInfo(currentFile.getPath());
+        RepoInfo repoInfo = Util.repoInfo(currentFile.getPath(), project);
 
         String q = sel.getSelectedText();
         if (q == null || q.equals("")) {
@@ -51,23 +51,6 @@ public abstract class SearchActionBase extends AnAction {
         String uri;
         String productName = ApplicationInfo.getInstance().getVersionName();
         String productVersion = ApplicationInfo.getInstance().getFullVersion();
-        // set defaultBranch if config option is not null
-        String branch = Util.setDefaultBranch(project)!=null ? Util.setDefaultBranch(project) : repoInfo.branch;
-        String remoteURL = repoInfo.remoteURL;
-
-        // replace remoteURL if config option is not null
-        if(Util.setRemoteUrlReplacements(project)!=null) {
-            String r = Util.setRemoteUrlReplacements(project);
-            String[] replacements = r.trim().split("\\s*,\\s*");
-            // Check if the entered values are pairs with no more than 2 pairs
-            Integer i = 0;
-            if(replacements.length%2==0 && replacements.length<=4) {
-                while(i< replacements.length) {
-                    remoteURL = remoteURL.replace(replacements[i], replacements[i+1]);
-                    i+=2;
-                }
-            }
-        }
 
         try {
             uri = Util.sourcegraphURL(project)+"-/editor"
@@ -78,8 +61,8 @@ public abstract class SearchActionBase extends AnAction {
                     + "&search=" + URLEncoder.encode(q, "UTF-8");
 
             if (mode == "search.repository") {
-                uri += "&search_remote_url=" + URLEncoder.encode(remoteURL, "UTF-8")
-                        + "&search_branch=" + URLEncoder.encode(branch, "UTF-8");
+                uri += "&search_remote_url=" + URLEncoder.encode(repoInfo.remoteURL, "UTF-8")
+                        + "&search_branch=" + URLEncoder.encode(repoInfo.branch, "UTF-8");
             }
 
         } catch (UnsupportedEncodingException err) {

--- a/src/main/java/SearchActionBase.java
+++ b/src/main/java/SearchActionBase.java
@@ -59,9 +59,13 @@ public abstract class SearchActionBase extends AnAction {
         if(Util.setRemoteUrlReplacements(project)!=null) {
             String r = Util.setRemoteUrlReplacements(project);
             String[] replacements = r.trim().split("\\s*,\\s*");
-            // Check if the entered values are pair
-            if(replacements.length==2) {
-                remoteURL = remoteURL.replace(replacements[0], replacements[1]);
+            // Check if the entered values are pairs with no more than 2 pairs
+            Integer i = 0;
+            if(replacements.length%2==0 && replacements.length<=4) {
+                while(i< replacements.length) {
+                    remoteURL = remoteURL.replace(replacements[i], replacements[i+1]);
+                    i+=2;
+                }
             }
         }
 

--- a/src/main/java/SearchActionBase.java
+++ b/src/main/java/SearchActionBase.java
@@ -51,12 +51,19 @@ public abstract class SearchActionBase extends AnAction {
         String uri;
         String productName = ApplicationInfo.getInstance().getVersionName();
         String productVersion = ApplicationInfo.getInstance().getFullVersion();
-        String branch = repoInfo.branch;
+        // set defaultBranch if config option is not null
+        String branch = Util.setDefaultBranch(project)!=null ? Util.setDefaultBranch(project) : repoInfo.branch;
+        String remoteURL = repoInfo.remoteURL;
 
-        // set defaultBranch only if not config is not null
-        if(Util.setDefaultBranch(project)!=null) {
-            branch = Util.setDefaultBranch(project);
-        };
+        // replace remoteURL if config option is not null
+        if(Util.setRemoteUrlReplacements(project)!=null) {
+            String r = Util.setRemoteUrlReplacements(project);
+            String[] replacements = r.trim().split("\\s*,\\s*");
+            // Check if the entered values are pair
+            if(replacements.length==2) {
+                remoteURL = remoteURL.replace(replacements[0], replacements[1]);
+            }
+        }
 
         try {
             uri = Util.sourcegraphURL(project)+"-/editor"
@@ -67,7 +74,7 @@ public abstract class SearchActionBase extends AnAction {
                     + "&search=" + URLEncoder.encode(q, "UTF-8");
 
             if (mode == "search.repository") {
-                uri += "&search_remote_url=" + URLEncoder.encode(repoInfo.remoteURL, "UTF-8")
+                uri += "&search_remote_url=" + URLEncoder.encode(remoteURL, "UTF-8")
                         + "&search_branch=" + URLEncoder.encode(branch, "UTF-8");
             }
 

--- a/src/main/java/Util.java
+++ b/src/main/java/Util.java
@@ -129,7 +129,7 @@ public class Util {
 
             if(r!=null) {
                 String[] replacements = r.trim().split("\\s*,\\s*");
-                // Check if the entered values are pairs with no more than 2 pairs
+                // Check if the entered values are pairs
                 for (int i = 0; i < replacements.length && replacements.length % 2 == 0; i += 2) {
                     remoteURL = remoteURL.replace(replacements[i], replacements[i+1]);
                 }
@@ -151,7 +151,7 @@ public class Util {
         BufferedReader stdout = new BufferedReader(new InputStreamReader(p.getInputStream()));
         BufferedReader stderr = new BufferedReader(new InputStreamReader(p.getErrorStream()));
 
-        // Log any stderr ouput.
+        // Log any stderr output.
         Logger logger = Logger.getInstance(Util.class);
         String s;
         while ((s = stderr.readLine()) != null) {

--- a/src/main/java/Util.java
+++ b/src/main/java/Util.java
@@ -2,7 +2,7 @@ import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.project.Project;
 
 import java.io.*;
-import java.util.Properties;
+import java.util.*;
 
 public class Util {
     public static String VERSION = "v1.2.1";
@@ -66,6 +66,16 @@ public class Util {
             defaultBranch = props.getProperty("defaultBranch", null);
         }
         return defaultBranch;
+    }
+
+    // get remoteUrlReplacements configuration option
+    public static String setRemoteUrlReplacements(Project project) {
+        String replacements = Config.getInstance(project).getRemoteUrlReplacements();
+        if (replacements == null || replacements.length() == 0) {
+            Properties props = readProps();
+            replacements = props.getProperty("remoteUrlReplacements", null);
+        }
+        return replacements;
     }
 
     // readProps tries to read the $HOME/sourcegraph-jetbrains.properties file.

--- a/src/main/java/Util.java
+++ b/src/main/java/Util.java
@@ -2,7 +2,7 @@ import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.project.Project;
 
 import java.io.*;
-import java.util.*;
+import java.util.Properties;
 
 public class Util {
     public static String VERSION = "v1.2.1";


### PR DESCRIPTION
This is a PR to add configure option `remoteUrlReplacements` used in [our VS Code plugin](https://github.com/sourcegraph/sourcegraph-vscode) which allows users to replace values in remote url.

Users can enable this feature by adding `remoteUrlReplacements` to their global configuration file `sourcegraph-jetbrains.properties` or repository-based configuration file `.idea/sourcegraph.xml`. 

This feature will not be enabled if less than two or more than four values were passed into the configuration.

## Examples

![image](https://user-images.githubusercontent.com/68532117/128238061-2e4b06e6-40e2-459e-821d-dc66c22a9254.png)
![image](https://user-images.githubusercontent.com/68532117/128238254-08fdd137-1f96-4a33-91b6-d659962a8ed9.png)
URL changed from https://github.com/sourcegraph/sourcegraph-jetbrains.git to https://gitexample.com/s/s-jetbrains.git using the configurations shown above
![image](https://user-images.githubusercontent.com/68532117/128237999-d1cf39a0-0f3a-4f08-bcdd-5a5042481c59.png)


This feature should address the request listed in https://github.com/sourcegraph/sourcegraph-jetbrains/issues/17