### PR TITLE
Fix: resolve SSH url for git menu

### DIFF
--- a/src/main/java/CommitViewUriBuilder.java
+++ b/src/main/java/CommitViewUriBuilder.java
@@ -15,8 +15,12 @@ public class CommitViewUriBuilder {
     }
 
     // this is pretty hacky but to try to build the repo string we will just try to naively parse the git remote uri. Worst case scenario this 404s
-    URI remote = URI.create(repoInfo.remoteURL);
-    String path = remote.getPath().replace(".git", "");
+    String remoteURL = repoInfo.remoteURL;
+    if(remoteURL.startsWith("git")){
+      remoteURL = repoInfo.remoteURL.replace(".git", "").replaceFirst(":", "/").replace("git@", "https://");;
+    }
+    URI remote = URI.create(remoteURL);
+    String path = remote.getPath();
 
     StringBuilder builder = new StringBuilder();
     try {


### PR DESCRIPTION
This PR is to address the issue stated in https://github.com/sourcegraph/sourcegraph-jetbrains/issues/25

The Open in Sourcegraph from the git menu feature is currently working for projects that are using HTTP as their remote URL, but not for projects that are using SSH due to the [command](https://github.com/sourcegraph/sourcegraph-jetbrains/blob/master/src/main/java/Util.java#L13) we run to get the URI. This fix is to turn URL that starts with `git` into HTTPS format in the url builder function for git menu.