### PR TITLE
Make plugin configurable via dotted `.sourcegraph-jetbrains.properties`

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ The plugin works with all JetBrains IDEs including:
 
 ## Configuring for use with a private Sourcegraph instance
 
-The plugin is configurable _globally_ by creating a `sourcegraph-jetbrains.properties` in your home directory. For example, modify the following URL to match your on-premises Sourcegraph instance URL:
+The plugin is configurable _globally_ by creating a `.sourcegraph-jetbrains.properties` in your home directory. For example, modify the following URL to match your on-premises Sourcegraph instance URL:
 
 ```
 url = https://sourcegraph.example.com

--- a/src/main/java/Util.java
+++ b/src/main/java/Util.java
@@ -2,6 +2,8 @@ import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.project.Project;
 
 import java.io.*;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Properties;
 
 public class Util {
@@ -78,26 +80,34 @@ public class Util {
         return replacements;
     }
 
-    // readProps tries to read the $HOME/sourcegraph-jetbrains.properties file.
+    // readProps returns the first properties file it's able to parse from the following paths:
+    //   $HOME/.sourcegraph-jetbrains.properties
+    //   $HOME/sourcegraph-jetbrains.properties
     private static Properties readProps() {
-        Properties props = new Properties();
-        InputStream input = null;
+        Path[] candidatePaths = {
+                Paths.get(System.getProperty("user.home"), ".sourcegraph-jetbrains.properties"),
+                Paths.get(System.getProperty("user.home"), "sourcegraph-jetbrains.properties"),
+        };
 
-        String path = System.getProperty("user.home") + File.separator + "sourcegraph-jetbrains.properties";
-        try{
-            input = new FileInputStream(path);
-            props.load(input);
-        } catch (IOException e) {
-            // no-op
-        } finally {
-            if (input != null) {
-                try{
-                    input.close();
-                } catch (IOException e) {
-                    // no-op
-                }
+        for (Path path : candidatePaths) {
+            File file = path.toFile();
+            try {
+                return readPropsPath(file);
+            } catch (IOException e) {
+                // no-op
             }
         }
+        // No files found/readable
+        return new Properties();
+    }
+
+    private static Properties readPropsPath(File file) throws IOException {
+        Properties props = new Properties();
+
+        try (InputStream input = new FileInputStream(file)) {
+            props.load(input);
+        }
+
         return props;
     }
 


### PR DESCRIPTION
Normally configuration files for tools (especially global configuration)
tend to begin with a dot to avoid showing up in file listings and other
tools (unless desired).

This change adds `.sourcegraph-jetbrains.properties` as a candidate path
to check for the global configuration file. Since dotted files are
conventional, the path mentioned in the README has been changed to
suggest the dotted file name.

The original filename is still read as a backup for backwards
compatibility.