### PR TITLE
Update min version

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ pluginVersion = 1.2.3
 
 # See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 # for insight into build numbers and IntelliJ Platform versions.
-pluginSinceBuild = 145.0
+pluginSinceBuild = 162.0
 pluginUntilBuild = 213.*
 
 # IntelliJ Platform Properties -> https://github.com/JetBrains/gradle-intellij-plugin#intellij-platform-properties


### PR DESCRIPTION
In the IntelliJ admin interface, I noticed that this was the value we used for the previous releases as well. It seems like the config file was wrong here:

![Screenshot 2022-01-31 at 11 21 21](https://user-images.githubusercontent.com/458591/151776593-6fa2fc63-906d-4f21-860a-0402deb84f08.png)

