### PR TITLE
Make the plugin work with JetBrains 2022.1 products

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+## [1.2.4]
+
+- Fixed an issue that prevent the latest version of the plugin to work with JetBrains 2022.1 products.
+
 ## [1.2.3]
 
 - Upgrade JetBrains IntelliJ shell to 1.3.1 and modernize the build and release pipeline.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,7 +6,7 @@ fun properties(key: String) = project.findProperty(key).toString()
 plugins {
     id("java")
     id("org.jetbrains.kotlin.jvm") version "1.6.10"
-    id("org.jetbrains.intellij") version "1.3.1"
+    id("org.jetbrains.intellij") version "1.5.3"
     id("org.jetbrains.changelog") version "1.3.1"
 }
 
@@ -50,7 +50,6 @@ tasks {
     patchPluginXml {
         version.set(properties("pluginVersion"))
         sinceBuild.set(properties("pluginSinceBuild"))
-        untilBuild.set(properties("pluginUntilBuild"))
 
         // Extract the <!-- Plugin description --> section from README.md and provide for the plugin's manifest
         pluginDescription.set(

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@
 pluginGroup = com.sourcegraph.jetbrains
 pluginName = Sourcegraph
 # SemVer format -> https://semver.org
-pluginVersion = 1.2.3
+pluginVersion = 1.2.4
 
 # See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 # for insight into build numbers and IntelliJ Platform versions.

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,11 +9,10 @@ pluginVersion = 1.2.3
 # See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 # for insight into build numbers and IntelliJ Platform versions.
 pluginSinceBuild = 162.0
-pluginUntilBuild = 213.*
 
 # IntelliJ Platform Properties -> https://github.com/JetBrains/gradle-intellij-plugin#intellij-platform-properties
 platformType = IC
-platformVersion = 2021.3
+platformVersion = 2022.1
 
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html
 # Example: platformPlugins = com.intellij.java, com.jetbrains.php:203.4449.22
@@ -23,7 +22,7 @@ platformPlugins =
 javaVersion = 11
 
 # Gradle Releases -> https://github.com/gradle/gradle/releases
-gradleVersion = 7.3.3
+gradleVersion = 7.4.2
 
 # Opt-out flag for bundling Kotlin standard library.
 # See https://plugins.jetbrains.com/docs/intellij/kotlin.html#kotlin-standard-library for details.


### PR DESCRIPTION
As pointed out by @abeatrix, the current version of the plugin is not available on 2022.1 IDEs. This is because we defined a  `pluginUntilBuild` rule prevent higher version numbers from running the extension.

This PR updates our SDK and wrapper versions as well as removes this boundary.

### Test plan

With the changes, run `./gradlew runIde`. This will start 2022.1. You can verify that this is loading the extension:

![Screenshot 2022-04-22 at 13 04 58](https://user-images.githubusercontent.com/458591/164703003-113485db-409f-4169-82f0-2f055fcae25b.png)

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
